### PR TITLE
Implementation of Program

### DIFF
--- a/Sources/SchwiftyPermissions/PermissionError.swift
+++ b/Sources/SchwiftyPermissions/PermissionError.swift
@@ -6,7 +6,7 @@
 //
 
 public enum PermissionError : Error {
-    case operationNotPermitted
+    case operationDenied
 
     case notOnWhitelist
     case onBlacklist

--- a/Sources/SchwiftyPermissions/PermissionStatus.swift
+++ b/Sources/SchwiftyPermissions/PermissionStatus.swift
@@ -5,14 +5,10 @@
 //  Created by Evan Anderson on 2/6/25.
 //
 
-// TODO: fix (Module [Foundation, FoundationEssentials] was not compiled with library evolution support; using it means binary compatibility for 'SchwiftyPermissions' can't be guaranteed)
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#elseif canImport(Foundation)
 import Foundation
-#endif
 
 /// List of available statuses a permission can have.
+//@available(macOS 13.0, *)
 public enum PermissionStatus : Hashable, Sendable {
     /// Access is never allowed.
     case never
@@ -32,16 +28,15 @@ public enum PermissionStatus : Hashable, Sendable {
     /// Access is only allowed if granted by the user, when requested.
     case uponRequest
 
-    #if canImport(FoundationEssentials) || canImport(Foundation)
     /// Access is only allowed temporarily, until a set time.
-    case temporarilyUntil(Date)
-    #endif
+    case temporarilyUntil(end:Date)
 
     /// Access is only allowed temporarily, between two given times of day.
     //case temporarilyBetween(Double, Double) // TODO: support
 }
 
 extension PermissionStatus {
+    ///
     @inlinable
     public func isAllowed(for state: ProgramState) -> Bool {
         switch self {
@@ -51,11 +46,7 @@ extension PermissionStatus {
         case .onlyInBackground: return state == .background
         case .onlyInForeground: return state == .foreground
         case .uponRequest: return true // TODO: fix
-
-        #if canImport(FoundationEssentials) || canImport(Foundation)
-        case .temporarilyUntil(let expires): return Date.now <= expires
-        #endif
-
+        case .temporarilyUntil(let endtime): return Date.now <= endtime
         @unknown default: return false
         }
     }

--- a/Sources/SchwiftyPermissions/PermissionStatus.swift
+++ b/Sources/SchwiftyPermissions/PermissionStatus.swift
@@ -5,6 +5,13 @@
 //  Created by Evan Anderson on 2/6/25.
 //
 
+// TODO: fix (Module [Foundation, FoundationEssentials] was not compiled with library evolution support; using it means binary compatibility for 'SchwiftyPermissions' can't be guaranteed)
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
+import Foundation
+#endif
+
 /// List of available statuses a permission can have.
 public enum PermissionStatus : Hashable, Sendable {
     /// Access is never allowed.
@@ -25,8 +32,10 @@ public enum PermissionStatus : Hashable, Sendable {
     /// Access is only allowed if granted by the user, when requested.
     case uponRequest
 
+    #if canImport(FoundationEssentials) || canImport(Foundation)
     /// Access is only allowed temporarily, until a set time.
-    case temporarilyUntil(ContinuousClock.Instant)
+    case temporarilyUntil(Date)
+    #endif
 
     /// Access is only allowed temporarily, between two given times of day.
     //case temporarilyBetween(Double, Double) // TODO: support
@@ -42,7 +51,11 @@ extension PermissionStatus {
         case .onlyInBackground: return state == .background
         case .onlyInForeground: return state == .foreground
         case .uponRequest: return true // TODO: fix
-        case .temporarilyUntil(let expires): return ContinuousClock.now <= expires
+
+        #if canImport(FoundationEssentials) || canImport(Foundation)
+        case .temporarilyUntil(let expires): return Date.now <= expires
+        #endif
+
         @unknown default: return false
         }
     }

--- a/Sources/SchwiftyPermissions/PermissionStorage.swift
+++ b/Sources/SchwiftyPermissions/PermissionStorage.swift
@@ -7,9 +7,13 @@
 
 /// Default storage that keeps track of process permissions.
 public struct PermissionStorage : Sendable {
+    /// The default target
     @MainActor public static private(set) var shared:PermissionStorage = PermissionStorage()
 
-    var programs:[UInt64:ProcessPermissions]
+    /// Public Access Subject to Change
+    // TODO: Evaluate Security considerations with viewing any program's permissions arbitrarily
+    // NOTE: replace public with internal
+    internal fileprivate(set) var programs:[Program.PID:[ProcessPermissions]]
 
     public init() {
         programs = [:]
@@ -17,4 +21,23 @@ public struct PermissionStorage : Sendable {
 
     public func load() {
     }
+
+    /// Registers a Program without Validation
+    /// - Warning: Ignores Permission Checks, do not expose this function
+    internal mutating func forceRegister(
+        _ perm:ProcessPermissions,
+        for program:Program
+    ) async {
+        do {
+            programs[await program.pid].append(perm)
+        } catch {
+            programs[await program.pid] = [perm]
+        }
+    }
+
+    internal func Register(for program: Program) {
+
+    }
+
+
 }

--- a/Sources/SchwiftyPermissions/ProcessPermissions.swift
+++ b/Sources/SchwiftyPermissions/ProcessPermissions.swift
@@ -9,7 +9,6 @@
 public struct ProcessPermissions : Sendable {
     var state:ProgramState
 
-    var calendar:CalendarPermission!
     var disk:DiskPermission! = nil
     var location:LocationPermission! = nil
     var manipulation:ManipulatePermission! = nil
@@ -19,7 +18,7 @@ public struct ProcessPermissions : Sendable {
 
     /*public mutating func get(
         for permission: SchwiftyPermission,
-        onBehalfOf pid: UInt64,
+        onBehalfOf program: Program,
         reason: String
     ) async -> AnyPermissionSnapshot {
         switch permission {
@@ -30,18 +29,18 @@ public struct ProcessPermissions : Sendable {
 
     public mutating func status(
         for permission: SchwiftyPermission,
-        onBehalfOf pid: UInt64,
+        onBehalfOf program: Program,
         reason: String
     ) async -> PermissionStatus {
-        return await get(for: permission, onBehalfOf: pid, reason: reason).status
+        return await get(for: permission, onBehalfOf: program, reason: reason).status
     }
-    
-    mutating func requestPermission<T: SchwiftyPermission>(
-        _ permission: T,
-        onBehalfOf pid: UInt64,
+
+    mutating func requestPermission<T: PermissionSnapshotData>(
+        _ permission: SchwiftyPermission,
+        onBehalfOf program: Program,
         reason: String
-    ) async -> Bool {
-        if let result:UInt8 = await promptPermission(permission, pid: pid, reason: reason), let p:PermissionStatus = PermissionStatus(rawValue: result) {
+    ) async -> PermissionSnapshot<T> {
+        if let result:UInt8 = await promptPermission(permission, requestor: Program, reason: reason), let p:PermissionStatus = PermissionStatus(rawValue: result) {
             // TODO: finish
             return PermissionSnapshot(status: p, data: T())
         }
@@ -52,7 +51,7 @@ public struct ProcessPermissions : Sendable {
     /// - Returns: The selected Permission Status code.
     func promptPermission(
         _ permission: SchwiftyPermission,
-        pid: UInt64,
+        requestor: Program,
         reason: String
     ) async -> UInt8? {
         // TODO: add UI prompt and completion handler callback

--- a/Sources/SchwiftyPermissions/ProcessPermissions.swift
+++ b/Sources/SchwiftyPermissions/ProcessPermissions.swift
@@ -9,6 +9,7 @@
 public struct ProcessPermissions : Sendable {
     var state:ProgramState
 
+    var calendar:CalendarPermission!
     var disk:DiskPermission! = nil
     var location:LocationPermission! = nil
     var manipulation:ManipulatePermission! = nil
@@ -18,7 +19,7 @@ public struct ProcessPermissions : Sendable {
 
     /*public mutating func get(
         for permission: SchwiftyPermission,
-        onBehalfOf program: UInt64,
+        onBehalfOf pid: UInt64,
         reason: String
     ) async -> AnyPermissionSnapshot {
         switch permission {
@@ -29,18 +30,18 @@ public struct ProcessPermissions : Sendable {
 
     public mutating func status(
         for permission: SchwiftyPermission,
-        onBehalfOf program: UInt64,
+        onBehalfOf pid: UInt64,
         reason: String
     ) async -> PermissionStatus {
-        return await get(for: permission, onBehalfOf: program, reason: reason).status
+        return await get(for: permission, onBehalfOf: pid, reason: reason).status
     }
-
-    mutating func requestPermission<T: PermissionSnapshotData>(
-        _ permission: SchwiftyPermission,
-        onBehalfOf program: UInt64,
+    
+    mutating func requestPermission<T: SchwiftyPermission>(
+        _ permission: T,
+        onBehalfOf pid: UInt64,
         reason: String
-    ) async -> PermissionSnapshot<T> {
-        if let result:UInt8 = await promptPermission(permission, requestor: program, reason: reason), let p:PermissionStatus = PermissionStatus(rawValue: result) {
+    ) async -> Bool {
+        if let result:UInt8 = await promptPermission(permission, pid: pid, reason: reason), let p:PermissionStatus = PermissionStatus(rawValue: result) {
             // TODO: finish
             return PermissionSnapshot(status: p, data: T())
         }
@@ -51,7 +52,7 @@ public struct ProcessPermissions : Sendable {
     /// - Returns: The selected Permission Status code.
     func promptPermission(
         _ permission: SchwiftyPermission,
-        requestor: UInt64,
+        pid: UInt64,
         reason: String
     ) async -> UInt8? {
         // TODO: add UI prompt and completion handler callback

--- a/Sources/SchwiftyPermissions/Program.swift
+++ b/Sources/SchwiftyPermissions/Program.swift
@@ -1,0 +1,91 @@
+//
+//  Program.swift
+//
+//
+//  Created by MinerMinerMods on 2/9/25.
+//
+
+/// Declares a Program with
+public actor Program {
+	public typealias PID = UInt64
+
+	public private(set) var name:String
+	public private(set) var pid:PID
+
+	/// Indicates the owner proccess.
+	/// - Warning: All programs are minimally owned by the root proccess
+	public private(set) var ownerpid:PID = 0
+
+	public internal(set) var permissions:[SchwiftyPermission] {
+		get { _permissions }
+		set (new) {
+			guard new != _permissions else { return }
+			guard _permissions.contains(.programRequestPermissionChanges) else {
+				throw PermissionError.requestDisallowed(reason:"Missing SchwiftyPermission.programRequestPermissionChanges")
+			}
+			for (i, item) in new.enumerated() {
+				if !(_permissions.contains(item)) {
+					do {
+						_permissions.append( try self.requestPermission(item).get() )
+					} catch(let error) {
+						print("Unable to authorize the permission: \(item).")
+						#if DEBUG
+							print(error)
+						#else
+							print("Use DEBUG for more info")
+						#endif
+					}
+				}
+			}
+		}
+	}
+
+	// To prevent a Program instance from arbitraily messing around with this from an extension
+	fileprivate var _permissions:[SchwiftyPermission] = []
+
+	public init(name:String? = nil, pid:PID) {
+		self.name = name ?? "Program \(pid)"
+		self.pid = pid
+	}
+
+	public func requestPermission(_ perm: SchwiftyPermission) throws -> Result<[ProcessPermissions], PermissionError> {
+		guard permissions.contains(SchwiftyPermission.programRequestPermissionChanges) || perm == SchwiftyPermission.programRequestPermissionChanges else { throw PermissionError.requestDisallowed(reason:"Missing Required Permission `.programRequestPermissionChanges`") }
+		guard permissions.contains(perm) else {return true}
+		var result = await requestPermission( for: SchwiftyPermission, onBehalfOf: self)
+		guard result.status != .never else {
+			return .failure(.operationDenied)
+		}
+		return .success(result)
+	}
+
+	/// Causes all access to
+	package func refreshPermissions() {
+		self.permissions = PermissionStorage.shared.programs[self]
+	}
+
+	internal func refreshPermissions(from permStore: PermissionStorage) {
+		self.permissions = permStore.programs[self.hash()]
+	}
+
+	package func updateRefrence(in permStore: PermissionStorage) {
+		permStore.changeRefrence(oldhash, currenthash)
+	}
+}
+
+extension Program:Hashable{
+	public isolated func hash() -> Int {
+		var hasher = Hasher()
+		self.hash(into: &hasher)
+		return hasher.finalize()
+	}
+
+	public isolated func hash(into hasher: inout Hasher) {
+		hasher.combine(pid)
+		hasher.combine(name)
+		hasher.combine(ownerpid)
+	}
+}
+
+extension Program: Equatable {
+
+}

--- a/Sources/SchwiftyPermissions/permissions/ManipulatePermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/ManipulatePermission.swift
@@ -9,15 +9,15 @@
 public struct ManipulatePermission : SchwiftyPermission {
     public private(set) var status:PermissionStatus
 
-    /// - Usage: [`Program Identifier` : `Program`]
-    var programs:[String:Program]
+    /// - Usage: [`Program`]
+    var programs:[Program]
 }
 
 // MARK: Default
 extension ManipulatePermission {
     public static let `default`:Self = Self(
         status: .never,
-        programs: [:]
+        programs: []
     )
 }
 

--- a/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
@@ -16,10 +16,10 @@ public struct NetworkPermission : SchwiftyPermission {
     public private(set) var urlBlacklist:Set<String>
 
     @usableFromInline
-    var downloadPermissions:ConnectionType.RawValue
+    var downloadPermissions:UInt8
 
     @usableFromInline
-    var uploadPermissions:ConnectionType.RawValue
+    var uploadPermissions:UInt8
 }
 
 // MARK: Default
@@ -35,42 +35,130 @@ extension NetworkPermission {
 
 // MARK: ConnectionType
 extension NetworkPermission {
-    public enum ConnectionType : UInt8, Sendable {
-        case local    = 1
-        case wired    = 2
-        case wireless = 4
-        case hotspot  = 8
-        case cellular = 16
-        case vpn      = 32
-    }
-}
-
-// MARK: Download
-extension NetworkPermission {
-    /// Whether or not a program can download data over the specified connection.
-    @inlinable
-    public func canDownload(over connection: ConnectionType) -> Bool {
-        return downloadPermissions & connection.rawValue != 0
+    public enum ConnectionType : Sendable {
+        case local
+        case wired
+        case wireless
+        case hotspot
+        case cellular
+        case vpn
     }
 
-    /// Whether or not a program can download data from the specified URL over the specified connection.
     @inlinable
     public func canDownload(from url: String, over connection: ConnectionType) -> Bool {
-        return canDownload(over: connection) && (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url)
+        guard (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url) else { return false }
+        switch connection {
+        case .local: return canDownloadLocal
+        case .wired: return canDownloadWired
+        case .wireless: return canDownloadWired
+        case .hotspot: return canDownloadHotspot
+        case .cellular: return canDownloadCellular
+        case .vpn: return canDownloadVPN
+        @unknown default: return false
+        }
+    }
+
+    @inlinable
+    public func canUpload(to url: String, over connection: ConnectionType) -> Bool {
+        guard (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url) else { return false }
+        switch connection {
+        case .local: return canUploadLocal
+        case .wired: return canUploadWired
+        case .wireless: return canUploadWired
+        case .hotspot: return canUploadHotspot
+        case .cellular: return canUploadCellular
+        case .vpn: return canUploadVPN
+        @unknown default: return false
+        }
     }
 }
 
-// MARK: Update
+// MARK: Local
 extension NetworkPermission {
-    /// Whether or not a program can upload data over the specified connection.
+    /// Whether or not a program can download data over the local network.
     @inlinable
-    public func canUpload(over connection: ConnectionType) -> Bool {
-        return uploadPermissions & connection.rawValue != 0
+    public var canDownloadLocal : Bool {
+        downloadPermissions & 0b1 != 0
     }
 
-    /// Whether or not a program can upload data to the specified URL over the specified connection.
+    /// Whether or not a program can upload data over the local network.
     @inlinable
-    public func canUpload(to url: String, over connection: ConnectionType) -> Bool {
-        return canUpload(over: connection) && (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url)
+    public var canUploadLocal : Bool {
+        uploadPermissions & 0b1 != 0
+    }
+}
+
+// MARK: Wired
+extension NetworkPermission {
+    /// Whether or not a program can download data over a wired connection.
+    @inlinable
+    public var canDownloadWired : Bool {
+        downloadPermissions & 0b01 != 0
+    }
+
+    /// Whether or not a program can upload data over a wired connection.
+    @inlinable
+    public var canUploadWired : Bool {
+        uploadPermissions & 0b01 != 0
+    }
+}
+
+// MARK: WIFI
+extension NetworkPermission {
+    /// Whether or not a program can download data over a wireless connection.
+    @inlinable
+    public var canDownloadWIFI : Bool {
+        downloadPermissions & 0b001 != 0
+    }
+
+    /// Whether or not a program can upload data over a wireless connection.
+    @inlinable
+    public var canUploadWIFI : Bool {
+        uploadPermissions & 0b001 != 0
+    }
+}
+
+// MARK: Hotspot
+extension NetworkPermission {
+    /// Whether or not a program can download data over a hotspot connection.
+    @inlinable
+    public var canDownloadHotspot : Bool {
+        downloadPermissions & 0b0001 != 0
+    }
+
+    /// Whether or not a program can upload data over a hotspot connection.
+    @inlinable
+    public var canUploadHotspot : Bool {
+        uploadPermissions & 0b0001 != 0
+    }
+}
+
+// MARK: Cellular
+extension NetworkPermission {
+    /// Whether or not a program can download data over a cellular connection.
+    @inlinable
+    public var canDownloadCellular : Bool {
+        downloadPermissions & 0b00001 != 0
+    }
+
+    /// Whether or not a program can upload data over a cellular connection.
+    @inlinable
+    public var canUploadCellular : Bool {
+        uploadPermissions & 0b00001 != 0
+    }
+}
+
+// MARK: VPN
+extension NetworkPermission {
+    /// Whether or not a program can download data over a vpn connection.
+    @inlinable
+    public var canDownloadVPN : Bool {
+        downloadPermissions & 0b000001 != 0
+    }
+
+    /// Whether or not a program can upload data over a vpn connection.
+    @inlinable
+    public var canUploadVPN : Bool {
+        uploadPermissions & 0b000001 != 0
     }
 }

--- a/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
@@ -16,10 +16,10 @@ public struct NetworkPermission : SchwiftyPermission {
     public private(set) var urlBlacklist:Set<String>
 
     @usableFromInline
-    var downloadPermissions:UInt8
+    var downloadPermissions:ConnectionType.RawValue
 
     @usableFromInline
-    var uploadPermissions:UInt8
+    var uploadPermissions:ConnectionType.RawValue
 }
 
 // MARK: Default
@@ -35,130 +35,42 @@ extension NetworkPermission {
 
 // MARK: ConnectionType
 extension NetworkPermission {
-    public enum ConnectionType : Sendable {
-        case local
-        case wired
-        case wireless
-        case hotspot
-        case cellular
-        case vpn
+    public enum ConnectionType : UInt8, Sendable {
+        case local    = 2
+        case wired    = 4
+        case wireless = 8
+        case hotspot  = 16
+        case cellular = 32
+        case vpn      = 64
+    }
+}
+
+// MARK: Download
+extension NetworkPermission {
+    /// Whether or not a program can download data over the specified connection.
+    @inlinable
+    public func canDownload(over connection: ConnectionType) -> Bool {
+        return downloadPermissions & connection.rawValue != 0
     }
 
+    /// Whether or not a program can download data from the specified URL over the specified connection.
     @inlinable
     public func canDownload(from url: String, over connection: ConnectionType) -> Bool {
-        guard (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url) else { return false }
-        switch connection {
-        case .local: return canDownloadLocal
-        case .wired: return canDownloadWired
-        case .wireless: return canDownloadWired
-        case .hotspot: return canDownloadHotspot
-        case .cellular: return canDownloadCellular
-        case .vpn: return canDownloadVPN
-        @unknown default: return false
-        }
+        return canDownload(over: connection) && (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url)
+    }
+}
+
+// MARK: Update
+extension NetworkPermission {
+    /// Whether or not a program can upload data over the specified connection.
+    @inlinable
+    public func canUpload(over connection: ConnectionType) -> Bool {
+        return uploadPermissions & connection.rawValue != 0
     }
 
+    /// Whether or not a program can upload data to the specified URL over the specified connection.
     @inlinable
     public func canUpload(to url: String, over connection: ConnectionType) -> Bool {
-        guard (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url) else { return false }
-        switch connection {
-        case .local: return canUploadLocal
-        case .wired: return canUploadWired
-        case .wireless: return canUploadWired
-        case .hotspot: return canUploadHotspot
-        case .cellular: return canUploadCellular
-        case .vpn: return canUploadVPN
-        @unknown default: return false
-        }
-    }
-}
-
-// MARK: Local
-extension NetworkPermission {
-    /// Whether or not a program can download data over the local network.
-    @inlinable
-    public var canDownloadLocal : Bool {
-        downloadPermissions & 0b1 != 0
-    }
-
-    /// Whether or not a program can upload data over the local network.
-    @inlinable
-    public var canUploadLocal : Bool {
-        uploadPermissions & 0b1 != 0
-    }
-}
-
-// MARK: Wired
-extension NetworkPermission {
-    /// Whether or not a program can download data over a wired connection.
-    @inlinable
-    public var canDownloadWired : Bool {
-        downloadPermissions & 0b01 != 0
-    }
-
-    /// Whether or not a program can upload data over a wired connection.
-    @inlinable
-    public var canUploadWired : Bool {
-        uploadPermissions & 0b01 != 0
-    }
-}
-
-// MARK: WIFI
-extension NetworkPermission {
-    /// Whether or not a program can download data over a wireless connection.
-    @inlinable
-    public var canDownloadWIFI : Bool {
-        downloadPermissions & 0b001 != 0
-    }
-
-    /// Whether or not a program can upload data over a wireless connection.
-    @inlinable
-    public var canUploadWIFI : Bool {
-        uploadPermissions & 0b001 != 0
-    }
-}
-
-// MARK: Hotspot
-extension NetworkPermission {
-    /// Whether or not a program can download data over a hotspot connection.
-    @inlinable
-    public var canDownloadHotspot : Bool {
-        downloadPermissions & 0b0001 != 0
-    }
-
-    /// Whether or not a program can upload data over a hotspot connection.
-    @inlinable
-    public var canUploadHotspot : Bool {
-        uploadPermissions & 0b0001 != 0
-    }
-}
-
-// MARK: Cellular
-extension NetworkPermission {
-    /// Whether or not a program can download data over a cellular connection.
-    @inlinable
-    public var canDownloadCellular : Bool {
-        downloadPermissions & 0b00001 != 0
-    }
-
-    /// Whether or not a program can upload data over a cellular connection.
-    @inlinable
-    public var canUploadCellular : Bool {
-        uploadPermissions & 0b00001 != 0
-    }
-}
-
-// MARK: VPN
-extension NetworkPermission {
-    /// Whether or not a program can download data over a vpn connection.
-    @inlinable
-    public var canDownloadVPN : Bool {
-        downloadPermissions & 0b000001 != 0
-    }
-
-    /// Whether or not a program can upload data over a vpn connection.
-    @inlinable
-    public var canUploadVPN : Bool {
-        uploadPermissions & 0b000001 != 0
+        return canUpload(over: connection) && (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url)
     }
 }

--- a/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
@@ -36,12 +36,12 @@ extension NetworkPermission {
 // MARK: ConnectionType
 extension NetworkPermission {
     public enum ConnectionType : UInt8, Sendable {
-        case local    = 2
-        case wired    = 4
-        case wireless = 8
-        case hotspot  = 16
-        case cellular = 32
-        case vpn      = 64
+        case local    = 1
+        case wired    = 2
+        case wireless = 4
+        case hotspot  = 8
+        case cellular = 16
+        case vpn      = 32
     }
 }
 

--- a/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
@@ -9,54 +9,46 @@
 public struct NotificationPermission : SchwiftyPermission {
     public private(set) var status:PermissionStatus
 
-    @usableFromInline
-    var permissions:UInt8
+    public private(set) var displayType:DisplayType
+
+    public private(set) var sound:String? // TODO: make struct
 
     @usableFromInline
-    var sendPermissions:AlertType.RawValue
+    var permissions:UInt8
 }
 
 // MARK: Default
 extension NotificationPermission {
     public static let `default`:Self = Self(
         status: .uponRequest,
-        permissions: .max,
-        sendPermissions: .max
+        displayType: .list,
+        sound: nil,
+        permissions: .max
     )
 }
 
-// MARK: AlertType
+// MARK: DisplayType
 extension NotificationPermission {
-    public enum AlertType : UInt8, Sendable {
-        /// Regular notification.
-        case normal        = 1
-
-        /// Warning, hazard, critical notification.
-        case critical      = 2
-
-        // TODO: add documentation
-        case timeSensitive = 4
-    }
-
-    @inlinable
-    public func canSend(_ alertType: AlertType = .normal) -> Bool {
-        return canSend && (sendPermissions & alertType.rawValue != 0)
+    public enum DisplayType : Sendable {
+        case count
+        case stack
+        case list
     }
 }
 
-// MARK: Send
+// MARK: Critical
 extension NotificationPermission {
-    @inlinable
-    public var canSend : Bool {
-        permissions & 0b1 != 0
-    }
+}
+
+// MARK: Time sensitive
+extension NotificationPermission {
 }
 
 // MARK: Badge
 extension NotificationPermission {
     @inlinable
     public var canShowBadge : Bool {
-        permissions & 0b01 != 0
+        permissions & 0b1 != 0
     }
 }
 
@@ -64,6 +56,6 @@ extension NotificationPermission {
 extension NotificationPermission {
     @inlinable
     public var canPlaySound : Bool {
-        permissions & 0b001 != 0
+        permissions & 0b01 != 0
     }
 }

--- a/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
@@ -27,15 +27,15 @@ extension NotificationPermission {
 
 // MARK: AlertType
 extension NotificationPermission {
-    public enum AlertType : UInt8 {
+    public enum AlertType : UInt8, Sendable {
         /// Regular notification.
-        case normal        = 2
+        case normal        = 1
 
         /// Warning, hazard, critical notification.
-        case critical      = 4
+        case critical      = 2
 
         // TODO: add documentation
-        case timeSensitive = 8
+        case timeSensitive = 4
     }
 
     @inlinable

--- a/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
@@ -11,14 +11,37 @@ public struct NotificationPermission : SchwiftyPermission {
 
     @usableFromInline
     var permissions:UInt8
+
+    @usableFromInline
+    var sendPermissions:AlertType.RawValue
 }
 
 // MARK: Default
 extension NotificationPermission {
     public static let `default`:Self = Self(
         status: .uponRequest,
-        permissions: .max
+        permissions: .max,
+        sendPermissions: .max
     )
+}
+
+// MARK: AlertType
+extension NotificationPermission {
+    public enum AlertType : UInt8 {
+        /// Regular notification.
+        case normal        = 2
+
+        /// Warning, hazard, critical notification.
+        case critical      = 4
+
+        // TODO: add documentation
+        case timeSensitive = 8
+    }
+
+    @inlinable
+    public func canSend(_ alertType: AlertType = .normal) -> Bool {
+        return canSend && (sendPermissions & alertType.rawValue != 0)
+    }
 }
 
 // MARK: Send
@@ -27,23 +50,13 @@ extension NotificationPermission {
     public var canSend : Bool {
         permissions & 0b1 != 0
     }
-
-    @inlinable
-    public var canSendCritical : Bool {
-        permissions & 0b01 != 0
-    }
-
-    @inlinable
-    public var canSendTimeSensitive : Bool {
-        permissions & 0b001 != 0
-    }
 }
 
 // MARK: Badge
 extension NotificationPermission {
     @inlinable
     public var canShowBadge : Bool {
-        permissions & 0b0001 != 0
+        permissions & 0b01 != 0
     }
 }
 
@@ -51,6 +64,6 @@ extension NotificationPermission {
 extension NotificationPermission {
     @inlinable
     public var canPlaySound : Bool {
-        permissions & 0b00001 != 0
+        permissions & 0b001 != 0
     }
 }

--- a/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
@@ -1,76 +1,69 @@
 //
-//  NetworkPermission.swift
+//  NotificationPermission.swift
 //
 //
 //  Created by Evan Anderson on 2/17/25.
 //
 
-/// Network permissions for a program.
-public struct NetworkPermission : SchwiftyPermission {
+/// Notification permissions for a program.
+public struct NotificationPermission : SchwiftyPermission {
     public private(set) var status:PermissionStatus
 
-    /// URLs the program is allowed to contact.
-    public private(set) var urlWhitelist:Set<String>
-
-    /// URLs the program is not allowed to contact.
-    public private(set) var urlBlacklist:Set<String>
+    @usableFromInline
+    var permissions:UInt8
 
     @usableFromInline
-    var downloadPermissions:ConnectionType.RawValue
-
-    @usableFromInline
-    var uploadPermissions:ConnectionType.RawValue
+    var sendPermissions:AlertType.RawValue
 }
 
 // MARK: Default
-extension NetworkPermission {
+extension NotificationPermission {
     public static let `default`:Self = Self(
         status: .uponRequest,
-        urlWhitelist: [],
-        urlBlacklist: [],
-        downloadPermissions: .max,
-        uploadPermissions: .max
+        permissions: .max,
+        sendPermissions: .max
     )
 }
 
-// MARK: ConnectionType
-extension NetworkPermission {
-    public enum ConnectionType : UInt8, Sendable {
-        case local    = 1
-        case wired    = 2
-        case wireless = 4
-        case hotspot  = 8
-        case cellular = 16
-        case vpn      = 32
+// MARK: AlertType
+extension NotificationPermission {
+    public enum AlertType : UInt8, Sendable {
+        /// Regular notification.
+        case normal        = 1
+
+        /// Warning, hazard, critical notification.
+        case critical      = 2
+
+        // TODO: add documentation
+        case timeSensitive = 4
+    }
+
+    @inlinable
+    public func canSend(_ alertType: AlertType = .normal) -> Bool {
+        return canSend && (sendPermissions & alertType.rawValue != 0)
     }
 }
 
-// MARK: Download
-extension NetworkPermission {
-    /// Whether or not a program can download data over the specified connection.
+// MARK: Send
+extension NotificationPermission {
     @inlinable
-    public func canDownload(over connection: ConnectionType) -> Bool {
-        return downloadPermissions & connection.rawValue != 0
-    }
-
-    /// Whether or not a program can download data from the specified URL over the specified connection.
-    @inlinable
-    public func canDownload(from url: String, over connection: ConnectionType) -> Bool {
-        return canDownload(over: connection) && (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url)
+    public var canSend : Bool {
+        permissions & 0b1 != 0
     }
 }
 
-// MARK: Update
-extension NetworkPermission {
-    /// Whether or not a program can upload data over the specified connection.
+// MARK: Badge
+extension NotificationPermission {
     @inlinable
-    public func canUpload(over connection: ConnectionType) -> Bool {
-        return uploadPermissions & connection.rawValue != 0
+    public var canShowBadge : Bool {
+        permissions & 0b01 != 0
     }
+}
 
-    /// Whether or not a program can upload data to the specified URL over the specified connection.
+// MARK: Sound
+extension NotificationPermission {
     @inlinable
-    public func canUpload(to url: String, over connection: ConnectionType) -> Bool {
-        return canUpload(over: connection) && (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url)
+    public var canPlaySound : Bool {
+        permissions & 0b001 != 0
     }
 }

--- a/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
@@ -9,10 +9,6 @@
 public struct NotificationPermission : SchwiftyPermission {
     public private(set) var status:PermissionStatus
 
-    public private(set) var displayType:DisplayType
-
-    public private(set) var sound:String? // TODO: make struct
-
     @usableFromInline
     var permissions:UInt8
 }
@@ -21,34 +17,33 @@ public struct NotificationPermission : SchwiftyPermission {
 extension NotificationPermission {
     public static let `default`:Self = Self(
         status: .uponRequest,
-        displayType: .list,
-        sound: nil,
         permissions: .max
     )
 }
 
-// MARK: DisplayType
+// MARK: Send
 extension NotificationPermission {
-    public enum DisplayType : Sendable {
-        case count
-        case stack
-        case list
+    @inlinable
+    public var canSend : Bool {
+        permissions & 0b1 != 0
     }
-}
 
-// MARK: Critical
-extension NotificationPermission {
-}
+    @inlinable
+    public var canSendCritical : Bool {
+        permissions & 0b01 != 0
+    }
 
-// MARK: Time sensitive
-extension NotificationPermission {
+    @inlinable
+    public var canSendTimeSensitive : Bool {
+        permissions & 0b001 != 0
+    }
 }
 
 // MARK: Badge
 extension NotificationPermission {
     @inlinable
     public var canShowBadge : Bool {
-        permissions & 0b1 != 0
+        permissions & 0b0001 != 0
     }
 }
 
@@ -56,6 +51,6 @@ extension NotificationPermission {
 extension NotificationPermission {
     @inlinable
     public var canPlaySound : Bool {
-        permissions & 0b01 != 0
+        permissions & 0b00001 != 0
     }
 }


### PR DESCRIPTION
This is a refactoring that fixes some compilation issues and implements `Program.swift` as part of Feature #2

- Added actor type `Program`
- Replaced Function Parameters referencing a programs `pid` value(`UInt64`) with `Program` and the functionality that inherently needed the `pid` now reference `Program.pid`
- Renamed `PermissionError.operationNotPermitted` to `PermissionError.operationDenied` for brevity
- Refactored `PermissionStatus.temorarilyUntil` to work with `Date`
- Improved Access Controls for `PermissionStorage.programs` to mitigate arbitrary access
- Added Register functions to `PermissionStorage`
- `ManipulatePermission.programs` no longer uses key lookup
- Added DocC comments for a future DocC build
- Replaced Access Controls for API/internal security