### PR TITLE
remove use of `@inlinable` annotation

### DIFF
--- a/Sources/SchwiftyPermissions/PermissionStorage.swift
+++ b/Sources/SchwiftyPermissions/PermissionStorage.swift
@@ -14,7 +14,6 @@ public actor PermissionStorage: Sendable {
     /// Shared permission storage.
     @MainActor public static private(set) var shared:PermissionStorage = PermissionStorage()
 
-    @usableFromInline
     var _system:SystemPermissions!
 
     /// System-wide permissions that all processes and programs inherit by default.
@@ -26,10 +25,8 @@ public actor PermissionStorage: Sendable {
         set { _system = newValue }
     }
 
-    @usableFromInline
     var programs:[Program.ApplicationID:ProcessPermissions]
 
-    @usableFromInline
     var processes:[Program.ProcessID:ProcessPermissions]
 
     public init(

--- a/Sources/SchwiftyPermissions/PermissionStorage.swift
+++ b/Sources/SchwiftyPermissions/PermissionStorage.swift
@@ -18,7 +18,6 @@ public actor PermissionStorage: Sendable {
     var _system:SystemPermissions!
 
     /// System-wide permissions that all processes and programs inherit by default.
-    @inlinable
     public private(set) var system: SystemPermissions {
         get {
             if _system == nil { _system = SystemPermissions() }
@@ -48,7 +47,6 @@ public actor PermissionStorage: Sendable {
 // MARK: Processes
 extension PermissionStorage {
     /// - Returns: Permissions for a process.
-    @inlinable
     public func permissions(for process: Program.ProcessID) -> ProcessPermissions {
         if let cached = processes[process] {
             return cached
@@ -75,7 +73,6 @@ extension PermissionStorage {
 // MARK: Programs
 extension PermissionStorage {
     /// - Returns: Permissions for a program.
-    @inlinable
     public func permissions(for program: Program) -> ProcessPermissions {
         if let cached = processes[program.pid] ?? programs[program.applicationID] {
             return cached

--- a/Sources/SchwiftyPermissions/ProcessPermissions.swift
+++ b/Sources/SchwiftyPermissions/ProcessPermissions.swift
@@ -9,7 +9,6 @@ public final class ProcessPermissions: @unchecked Sendable {
     var _notifications:NotificationPermission! = nil
     var _wallet:WalletPermission! = nil
 
-    @usableFromInline
     init() {
     }
 }
@@ -35,7 +34,6 @@ extension ProcessPermissions {
         return .success(perm)
     }
 
-    @usableFromInline
     func getOrLoad<T: SchwiftyPermission>(
         _ permission: SchwiftyPermissionType,
         for program: Program

--- a/Sources/SchwiftyPermissions/ProcessPermissions.swift
+++ b/Sources/SchwiftyPermissions/ProcessPermissions.swift
@@ -16,7 +16,6 @@ public final class ProcessPermissions: @unchecked Sendable {
 
 // MARK: Program
 extension ProcessPermissions {
-    @inlinable
     public func request<T: SchwiftyPermission>(
         _ permission: SchwiftyPermissionType,
         for program: Program,

--- a/Sources/SchwiftyPermissions/Program.swift
+++ b/Sources/SchwiftyPermissions/Program.swift
@@ -29,7 +29,6 @@ public struct Program: Sendable {
 
 // MARK: Equatable
 extension Program: Equatable {
-    @inlinable
     public static func == (lhs: Program, rhs: Program) -> Bool {
         return lhs.ownerpid == rhs.ownerpid && lhs.pid == rhs.pid
     }
@@ -37,7 +36,6 @@ extension Program: Equatable {
 
 // MARK: Hashable
 extension Program: Hashable {
-    @inlinable
     public func hash(into hasher: inout Hasher) {
         hasher.combine(ownerpid)
         hasher.combine(pid)
@@ -51,7 +49,6 @@ extension Program {
     /// - Parameters:
     ///   - permission: Permission you want to request.
     ///   - reason: Reason why the program is requesting the permission.
-    @inlinable
     public func request<T: SchwiftyPermission>(
         _ permission: SchwiftyPermissionType,
         reason: String

--- a/Sources/SchwiftyPermissions/ProgramState.swift
+++ b/Sources/SchwiftyPermissions/ProgramState.swift
@@ -17,7 +17,6 @@ public enum ProgramState: Hashable, Sendable {
 
 extension ProgramState {
     /// Whether or not this program state allows the use of a permission, given its status.
-    @inlinable
     public func allowsPermissionStatus(_ status: PermissionStatus) -> Bool {
         switch status {
         case .never: return false

--- a/Sources/SchwiftyPermissions/SchwiftyPermission.swift
+++ b/Sources/SchwiftyPermissions/SchwiftyPermission.swift
@@ -18,13 +18,11 @@ public protocol SchwiftyPermission: Sendable {
 }
 
 extension SchwiftyPermission {
-    @inlinable
     public static func loadSettings(for program: Program) -> Self {
         // TODO: return existing settings for application id
         return .default
     }
 
-    @inlinable
     public static func loadSystemSettings() -> Self {
         // TODO: return existing settings from disk
         return .default

--- a/Sources/SchwiftyPermissions/SystemPermissions.swift
+++ b/Sources/SchwiftyPermissions/SystemPermissions.swift
@@ -8,7 +8,6 @@ public final class SystemPermissions: @unchecked Sendable {
     var _notifications:NotificationPermission! = nil
     var _wallet:WalletPermission! = nil
 
-    @usableFromInline
     init() {
     }
 }

--- a/Sources/SchwiftyPermissions/permissions/CalendarPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/CalendarPermission.swift
@@ -58,7 +58,6 @@ extension CalendarPermission {
 
 // MARK: Read
 extension CalendarPermission {
-    @inlinable
     public var canRead: Bool {
         readPermissions & 0b1 != 0
     }
@@ -66,7 +65,6 @@ extension CalendarPermission {
 
 // MARK: Write
 extension CalendarPermission {
-    @inlinable
     public var canWrite: Bool {
         writePermissions & 0b1 != 0
     }

--- a/Sources/SchwiftyPermissions/permissions/CalendarPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/CalendarPermission.swift
@@ -5,10 +5,8 @@ public struct CalendarPermission: SchwiftyPermission {
     
     public private(set) var status:PermissionStatus
 
-    @usableFromInline
     var readPermissions:UInt8
 
-    @usableFromInline
     var writePermissions:UInt8
 }
 

--- a/Sources/SchwiftyPermissions/permissions/DiskPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/DiskPermission.swift
@@ -17,7 +17,6 @@ public struct DiskPermission: SchwiftyPermission {
     /// Absolute paths the process cannot write to.
     public private(set) var pathWriteBlacklist:Set<String>
 
-    @usableFromInline
     var permissions:UInt8
 }
 

--- a/Sources/SchwiftyPermissions/permissions/DiskPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/DiskPermission.swift
@@ -41,7 +41,6 @@ extension DiskPermission {
         // TODO: support move?
     }
 
-    @inlinable
     public func canPerform(state: ProgramState, action: Action) -> Bool {
         guard state.allowsPermissionStatus(status) else { return false }
         switch action {
@@ -58,7 +57,6 @@ extension DiskPermission {
 // MARK: Read
 extension DiskPermission {
     /// Whether or not a process can read from the disk.
-    @inlinable
     public var canRead: Bool {
         permissions & 0b1 != 0
     }
@@ -67,7 +65,6 @@ extension DiskPermission {
 // MARK: Write
 extension DiskPermission {
     /// Whether or not a process can write to the disk.
-    @inlinable
     public var canWrite: Bool {
         permissions & 0b01 != 0
     }

--- a/Sources/SchwiftyPermissions/permissions/ManipulatePermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/ManipulatePermission.swift
@@ -25,7 +25,6 @@ extension ManipulatePermission {
 extension ManipulatePermission {
     /// Permissions for a process that can be manipulated.
     public struct Process: Hashable, Sendable {
-        @usableFromInline
         var permissions:Permission.RawValue
     }
 }

--- a/Sources/SchwiftyPermissions/permissions/ManipulatePermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/ManipulatePermission.swift
@@ -38,7 +38,6 @@ extension ManipulatePermission.Process {
         case changePermissionsWithoutUserInteraction = 1
     }
 
-    @inlinable
     public func hasPermission(to permission: Permission) -> Bool {
         return permissions & permission.rawValue != 0
     }

--- a/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
@@ -25,10 +25,8 @@ public struct NetworkPermission: SchwiftyPermission {
     /// Network quotas for connection types.
     public private(set) var quotas:Quotas?
 
-    @usableFromInline
     var downloadPermissions:ConnectionType.RawValue
 
-    @usableFromInline
     var uploadPermissions:ConnectionType.RawValue
 }
 

--- a/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
@@ -84,13 +84,11 @@ extension NetworkPermission {
 // MARK: Download
 extension NetworkPermission {
     /// Whether or not a process can download data over the specified connection.
-    @inlinable
     public func canDownload(over connection: ConnectionType) -> Bool {
         return downloadPermissions & connection.rawValue != 0
     }
 
     /// Whether or not a process can download data from the specified URL over the specified connection.
-    @inlinable
     public func canDownload(from url: String, over connection: ConnectionType) -> Bool {
         return canDownload(over: connection) && (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url)
     }
@@ -99,13 +97,11 @@ extension NetworkPermission {
 // MARK: Upload
 extension NetworkPermission {
     /// Whether or not a process can upload data over the specified connection.
-    @inlinable
     public func canUpload(over connection: ConnectionType) -> Bool {
         return uploadPermissions & connection.rawValue != 0
     }
 
     /// Whether or not a process can upload data to the specified URL over the specified connection.
-    @inlinable
     public func canUpload(to url: String, over connection: ConnectionType) -> Bool {
         return canUpload(over: connection) && (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url)
     }

--- a/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
@@ -34,7 +34,6 @@ extension NotificationPermission {
         case timeSensitive = 4
     }
 
-    @inlinable
     public func canSend(_ alertType: AlertType = .normal) -> Bool {
         return canSend && (sendPermissions & alertType.rawValue != 0)
     }
@@ -42,7 +41,6 @@ extension NotificationPermission {
 
 // MARK: Send
 extension NotificationPermission {
-    @inlinable
     public var canSend: Bool {
         permissions & 0b1 != 0
     }
@@ -50,7 +48,6 @@ extension NotificationPermission {
 
 // MARK: Badge
 extension NotificationPermission {
-    @inlinable
     public var canShowBadge: Bool {
         permissions & 0b01 != 0
     }
@@ -58,7 +55,6 @@ extension NotificationPermission {
 
 // MARK: Sound
 extension NotificationPermission {
-    @inlinable
     public var canPlaySound: Bool {
         permissions & 0b001 != 0
     }

--- a/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NotificationPermission.swift
@@ -5,10 +5,8 @@ public struct NotificationPermission: SchwiftyPermission {
 
     public private(set) var status:PermissionStatus
 
-    @usableFromInline
     var permissions:UInt8
 
-    @usableFromInline
     var sendPermissions:AlertType.RawValue
 }
 

--- a/Sources/SchwiftyPermissions/util/NetworkBandwidthLimit.swift
+++ b/Sources/SchwiftyPermissions/util/NetworkBandwidthLimit.swift
@@ -13,7 +13,6 @@ public struct NetworkBandwidthLimit: Sendable {
 // MARK: NetworkPermission
 extension NetworkPermission {
     /// - Returns: The `NetworkBandwidthLimit` for a `ConnectionType`.
-    @inlinable
     public func bandwidthLimit(for connection: ConnectionType) -> NetworkBandwidthLimit? {
         switch connection {
         case .local: return bandwidthLimits?.local
@@ -28,7 +27,6 @@ extension NetworkPermission {
 
     /// - Returns: The active `NetworkBandwidthLimit` for a `ConnectionType`.
     /// Defaults to the system network bandwidth limit for the connection type, if configured.
-    @inlinable
     public func activeBandwidthLimit(for connection: ConnectionType) async -> NetworkBandwidthLimit? {
         var limit = bandwidthLimit(for: connection)
         if limit == nil {

--- a/Sources/SchwiftyPermissions/util/NetworkQuota.swift
+++ b/Sources/SchwiftyPermissions/util/NetworkQuota.swift
@@ -34,7 +34,6 @@ public struct NetworkQuota: Sendable {
 // MARK: NetworkPermission
 extension NetworkPermission {
     /// - Returns: The `NetworkQuota` for a `ConnectionType`.
-    @inlinable
     public func quota(for connection: ConnectionType) -> NetworkQuota? {
         switch connection {
         case .local: return quotas?.local
@@ -49,7 +48,6 @@ extension NetworkPermission {
 
     /// - Returns: The active `NetworkQuota` for a `ConnectionType`.
     /// Defaults to the system network quota for the connection type, if configured.
-    @inlinable
     public func activeQuota(for connection: ConnectionType) async -> NetworkQuota? {
         var quota = quota(for: connection)
         if quota == nil {
@@ -65,14 +63,12 @@ extension NetworkPermission {
     }
     
     /// - Returns: Whether or not a number of bytes can be downloaded over a connection type, taking into account the active quota.
-    @inlinable
     public func canDownload(bytes: UInt64, over connection: ConnectionType) async -> Bool {
         guard let quota = await activeQuota(for: connection) else { return true }
         return quota.downloaded + bytes <= quota.download
     }
 
     /// - Returns: Whether or not a number of bytes can be uploaded over a connection type, taking into account the active quota.
-    @inlinable
     public func canUpload(bytes: UInt64, over connection: ConnectionType) async -> Bool {
         guard let quota = await activeQuota(for: connection) else { return true }
         return quota.uploaded + bytes <= quota.upload


### PR DESCRIPTION
I've used the `@inlinable` extensively in other projects, and it usually doesn't help runtime performance meaningfully or actually makes it worse.

We should adopt the annotation only where gains are measured, not everywhere by default.